### PR TITLE
force description read as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='ecoji',
     version=__version__,
     description='Encode and decode data as emojis.',
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     author='mecforlove',
     author_email='mecforlove@outlook.com',
     url='https://github.com/mecforlove/ecoji-py',


### PR DESCRIPTION
Fix #4 

Python 3.12 on Windows expects files to use `cp1252` encoding by default.  This revision informs the `open` call to treat the `README.md` file as `utf-8` allowing the file to be read consistently.

Tested support on Windows/Linux/MacOS.